### PR TITLE
The divs in the ad group were getting nested inside each parent div a…

### DIFF
--- a/public/class-wpadcenter-public.php
+++ b/public/class-wpadcenter-public.php
@@ -968,6 +968,7 @@ class Wpadcenter_Public {
 					'placement_id'    => $attributes['placement_id'],
 				);
 				$adgroup_html        .= self::display_single_ad( $ad_id, $single_ad_attributes );
+				$adgroup_html .= '</div>';
 				$ad_count++;
 				$col_count++;
 				if ( intval( $attributes['num_ads'] ) === $ad_count || intval( $attributes['num_columns'] ) === $col_count ) {


### PR DESCRIPTION
The columns in the ad group were not displaying as expected and the divs in the adgroup child ads were getting nested inside each ad and which was causing the issue.
Added code to close the div after each ad. 