### PR TITLE
Cast "random order" attribute to boolean

### DIFF
--- a/admin/class-wpadcenter-admin.php
+++ b/admin/class-wpadcenter-admin.php
@@ -3082,7 +3082,7 @@ class Wpadcenter_Admin {
 
 		$ad_order = 'off';
 		if ( array_key_exists( 'ad_order', $attributes ) ) {
-			$checked = filter_var($attributes['ad_order'], FILTER_VALIDATE_BOOLEAN);
+			$checked = filter_var( $attributes['ad_order'], FILTER_VALIDATE_BOOLEAN );
 			if ( true === $checked ) {
 				$ad_order = 'on';
 			} else {

--- a/admin/class-wpadcenter-admin.php
+++ b/admin/class-wpadcenter-admin.php
@@ -3082,8 +3082,8 @@ class Wpadcenter_Admin {
 
 		$ad_order = 'off';
 		if ( array_key_exists( 'ad_order', $attributes ) ) {
-			$checked = $attributes['ad_order'];
-			if ( 'true' === $checked ) {
+			$checked = filter_var($attributes['ad_order'], FILTER_VALIDATE_BOOLEAN);
+			if ( true === $checked ) {
 				$ad_order = 'on';
 			} else {
 				$ad_order = 'off';


### PR DESCRIPTION
I've found a bug where "random order" attribute is expected to be string in the code, where in reality it is boolean

https://github.com/wpeka/wpadcenter/blob/245b7815c76d59eb327929cadcdbbcc54a5f413b/admin/class-wpadcenter-admin.php#L2959-L2962

This PR allows this attribute to be still string (maybe there are some cases like that), but it also handles boolean values correctly.